### PR TITLE
Add shorthand declaration example; Fix compilation errors on setting noImplicitAny to true

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,17 @@ server.route({
   }
 })
 
+// or using the short hand declaration
+server.post(
+  '/profile',
+  { preHandler: upload.single('avatar') },
+  function(request, reply) {
+    // request.file is the `avatar` file
+    // request.body will hold the text fields, if there were any
+    reply.code(200).send('SUCCESS')
+  }
+)
+
 server.route({
   method: 'POST',
   url: '/photos/upload',

--- a/src/lib/content-parser.ts
+++ b/src/lib/content-parser.ts
@@ -12,7 +12,7 @@ function setMultipart(req: IncomingMessage, done: (err: Error | null) => void) {
 }
 
 export function isMultipart(this: FastifyRequest<IncomingMessage>): boolean {
-  return this.req[kMultipart] || false
+  return (this.req as any)[kMultipart] || false
 }
 
 function fastifyMulter(fastify: FastifyInstance, options: PluginOptions, next: nextCallback) {

--- a/src/lib/file-appender.ts
+++ b/src/lib/file-appender.ts
@@ -1,5 +1,5 @@
 import { FastifyRequest } from 'fastify'
-import { File } from '../interfaces'
+import { File, FilesObject } from '../interfaces'
 
 export type Strategy = 'NONE' | 'VALUE' | 'ARRAY' | 'OBJECT'
 type Placeholder = {
@@ -50,10 +50,10 @@ class FileAppender {
         ;(this.request.files as Partial<File>[]).push(placeholder)
         break
       case 'OBJECT':
-        if (this.request.files[file.fieldname]) {
-          this.request.files[file.fieldname].push(placeholder)
+        if ((this.request.files as FilesObject)[file.fieldname]) {
+          ;(this.request.files as FilesObject)[file.fieldname].push(placeholder)
         } else {
-          this.request.files[file.fieldname] = [placeholder]
+          ;(this.request.files as FilesObject)[file.fieldname] = [placeholder]
         }
         break
     }
@@ -70,10 +70,10 @@ class FileAppender {
         arrayRemove(this.request.files as Partial<File>[], placeholder)
         break
       case 'OBJECT':
-        if (this.request.files[placeholder.fieldname].length === 1) {
-          delete this.request.files[placeholder.fieldname]
+        if ((this.request.files as FilesObject)[placeholder.fieldname].length === 1) {
+          delete (this.request.files as FilesObject)[placeholder.fieldname]
         } else {
-          arrayRemove(this.request.files[placeholder.fieldname], placeholder)
+          arrayRemove((this.request.files as FilesObject)[placeholder.fieldname], placeholder)
         }
         break
     }


### PR DESCRIPTION
1. Added shorthand declaration example for users who are already working on existing routes and maybe are new to fastify coming from Express.

2. When setting noImplicitAny to true, typescript compilation fails. All I did was added type assertion. Also fixes #5 