### PR TITLE
Update repository URL in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "Linus Unnebäck <linus@folkdatorn.se>"
   ],
   "license": "MIT",
-  "repository": "https://github.com/fox1t/multer",
+  "repository": "https://github.com/fox1t/fastify-multer",
   "keywords": [
     "form",
     "post",


### PR DESCRIPTION
It seems that the old /multer URL is deprecated. Hopefully I've understood this right?

This PR updates the URL in package.json to reflect the current source location.

Reason: When I use npm-check CLI tool to check version of modules in my project, it is directing me to the OLD url to check changes for fastify-multer. Then I have to click to open the moved repository. It would be more convenient if the repository URL was accurate.

![image](https://user-images.githubusercontent.com/37786000/82437605-a7f6cb00-9ad2-11ea-9e62-14d3f98f25cb.png)

By the way, npm-check is trying to guess the homepage URL using this logic:

https://github.com/dylang/npm-check/blob/master/lib/in/best-guess-homepage.js

The old URL is also showing on NPM website:
https://www.npmjs.com/package/fastify-multer