### PR TITLE
chore: support noUncheckedIndexedAccess

### DIFF
--- a/src/lib/file-appender.ts
+++ b/src/lib/file-appender.ts
@@ -49,13 +49,16 @@ class FileAppender {
       case 'ARRAY':
         ;(this.request.files as Partial<File>[]).push(placeholder)
         break
-      case 'OBJECT':
-        if ((this.request.files as FilesObject)[file.fieldname]) {
-          ;(this.request.files as FilesObject)[file.fieldname].push(placeholder)
+      case 'OBJECT': {
+        const files = (this.request.files as FilesObject)[file.fieldname]
+
+        if (files) {
+          files.push(placeholder)
         } else {
           ;(this.request.files as FilesObject)[file.fieldname] = [placeholder]
         }
         break
+      }
     }
 
     return placeholder
@@ -71,10 +74,14 @@ class FileAppender {
         break
       case 'OBJECT':
         if (placeholder.fieldname) {
-          if ((this.request.files as FilesObject)[placeholder.fieldname].length === 1) {
-            delete (this.request.files as FilesObject)[placeholder.fieldname]
-          } else {
-            arrayRemove((this.request.files as FilesObject)[placeholder.fieldname], placeholder)
+          const files = (this.request.files as FilesObject)[placeholder.fieldname]
+
+          if (files) {
+            if (files.length === 1) {
+              delete (this.request.files as FilesObject)[placeholder.fieldname]
+            } else {
+              arrayRemove(files, placeholder)
+            }
           }
         }
         break

--- a/src/lib/remove-uploaded-files.ts
+++ b/src/lib/remove-uploaded-files.ts
@@ -14,7 +14,7 @@ function removeUploadedFiles(
   }
 
   function handleFile(idx: number) {
-    const file = uploadedFiles[idx]
+    const file = uploadedFiles[idx]!
 
     remove(file, function(err?: RemoveUploadedFileError | null) {
       if (err) {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,6 +8,7 @@
     "pretty": true,
     "noEmitOnError": true,
     "experimentalDecorators": true,
+    "noUncheckedIndexedAccess": true,
     "sourceMap": true,
     "emitDecoratorMetadata": true,
     "strict": true,


### PR DESCRIPTION
Trying to use this library and setting `noUncheckedIndexedAccess` to `true`  in `tsconfig.json` will result in compilation errors.

I'm not sure why typescript keeps checking node_modules library when I have `skipLibCheck: true`  so I've decided to make fastify-multer more compliant with a stricter typescript settings. This PR doesn't affect the functionality.

You can see docs for this option here https://devblogs.microsoft.com/typescript/announcing-typescript-4-1-beta/#no-unchecked-indexed-access