### PR TITLE
fix(content-type): Fastify v5 parser leads to HTTP 415

### DIFF
--- a/src/lib/content-parser.ts
+++ b/src/lib/content-parser.ts
@@ -24,7 +24,7 @@ function fastifyMulter(
   _options: PluginOptions,
   next: (err?: Error) => void,
 ) {
-  fastify.addContentTypeParser('multipart', setMultipart)
+  fastify.addContentTypeParser(['multipart', 'multipart/form-data'], setMultipart)
   fastify.decorateRequest('isMultipart', isMultipart)
 
   next()


### PR DESCRIPTION
Fix fox1t/fastify-multer#35